### PR TITLE
(fix) deletePortMapping failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 0.13.2 - 2020-01-08
+
+- fix deletePortMapping failure
+
 ## 0.13.1 - 2020-01-08
 
 - use host name instead of IP address for new connection

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "soracom-napter-tools-vscode",
   "displayName": "SORACOM Napter Tools",
   "description": "Manage SORACOM Napter port mappings from Visual Studio Code.",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "publisher": "0x6b",
   "repository": {
     "type": "git",

--- a/src/model/SoracomModel.ts
+++ b/src/model/SoracomModel.ts
@@ -61,7 +61,7 @@ export class SoracomModel {
   public async deletePortMapping(endpoint: string): Promise<string> {
     const { status, statusText } = await this.client.callApi({
       method: "DELETE",
-      path: `/v1/port_mappings/${endpoint.replace(/:/, "/")}`
+      path: `/v1/port_mappings/${endpoint.replace(".napter.soracom.io", "").replace(/-/g, ".").replace(/:/, "/")}`
     });
     if (status !== 204) {
       throw new Error(statusText);


### PR DESCRIPTION
API only accepts endpoint IP address as path parameter